### PR TITLE
feat: add support for int-based (auto-increment) primary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,6 @@ print(data["orders"])
 # 4         5            3    Fitness Tracker         2
 ```
 
-**Key features:**
-- **Auto-increment integer PKs**: Automatically assigned sequential integers (1, 2, 3...) that guarantee uniqueness
-- **String PKs**: Can be used when you need the LLM to generate custom primary key values (e.g., "CUST-001", "ORD-ABC")
-- **Integer PKs always require auto_increment=True** to ensure unique values
-
 6. Create your first self-referencing mock table
 
 ```python

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ tables = {
     "customers": {
         "prompt": "Customers of an e-commerce store",
         "columns": {
-            "customer_id": {"dtype": "integer", "auto_increment": True},
+            "customer_id": {"dtype": "integer"},
             "name": {"prompt": "first name and last name", "dtype": "string"},
             "email": {"prompt": "email address", "dtype": "string"},
         },
@@ -188,7 +188,7 @@ tables = {
     "orders": {
         "prompt": "Customer orders",
         "columns": {
-            "order_id": {"dtype": "integer", "auto_increment": True},
+            "order_id": {"dtype": "integer"},
             "customer_id": {"dtype": "integer"},
             "product_name": {"prompt": "product name", "dtype": "string"},
             "quantity": {"prompt": "quantity ordered", "dtype": "integer"},

--- a/README.md
+++ b/README.md
@@ -170,6 +170,64 @@ print(data["items"])
 # 9  B4-200510  B1-3010022         Bottled Spring Water (24 Pack)   34.95
 ```
 
+5. Create tables with auto-increment integer primary keys
+
+```python
+from mostlyai import mock
+
+tables = {
+    "customers": {
+        "prompt": "Customers of an e-commerce store",
+        "columns": {
+            "customer_id": {"dtype": "integer", "auto_increment": True},
+            "name": {"prompt": "first name and last name", "dtype": "string"},
+            "email": {"prompt": "email address", "dtype": "string"},
+        },
+        "primary_key": "customer_id",
+    },
+    "orders": {
+        "prompt": "Customer orders",
+        "columns": {
+            "order_id": {"dtype": "integer", "auto_increment": True},
+            "customer_id": {"dtype": "integer"},
+            "product_name": {"prompt": "product name", "dtype": "string"},
+            "quantity": {"prompt": "quantity ordered", "dtype": "integer"},
+        },
+        "primary_key": "order_id",
+        "foreign_keys": [
+            {
+                "column": "customer_id",
+                "referenced_table": "customers",
+                "prompt": "each customer has between 1 and 3 orders",
+            },
+        ],
+    },
+}
+data = mock.sample(
+    tables=tables,
+    sample_size=3,
+    model="openai/gpt-4o-mini",
+    n_workers=4,
+)
+print(data["customers"])
+#   customer_id             name                     email
+# 0            1        John Smith       john.smith@example.com
+# 1            2      Emily Johnson    emily.johnson@example.com
+# 2            3   Michael Williams michael.williams@example.com
+print(data["orders"])
+#   order_id  customer_id      product_name  quantity
+# 0         1            1  Wireless Headphones         2
+# 1         2            1    Fitness Tracker         1
+# 2         3            2     Phone Charger         3
+# 3         4            2  Wireless Headphones         1
+# 4         5            3    Fitness Tracker         2
+```
+
+**Key features:**
+- **Auto-increment integer PKs**: Automatically assigned sequential integers (1, 2, 3...) that guarantee uniqueness
+- **String PKs**: Can be used when you need the LLM to generate custom primary key values (e.g., "CUST-001", "ORD-ABC")
+- **Integer PKs always require auto_increment=True** to ensure unique values
+
 6. Create your first self-referencing mock table
 
 ```python

--- a/README.md
+++ b/README.md
@@ -170,60 +170,7 @@ print(data["items"])
 # 9  B4-200510  B1-3010022         Bottled Spring Water (24 Pack)   34.95
 ```
 
-5. Create tables with auto-increment integer primary keys
-
-```python
-from mostlyai import mock
-
-tables = {
-    "customers": {
-        "prompt": "Customers of an e-commerce store",
-        "columns": {
-            "customer_id": {"dtype": "integer"},
-            "name": {"prompt": "first name and last name", "dtype": "string"},
-            "email": {"prompt": "email address", "dtype": "string"},
-        },
-        "primary_key": "customer_id",
-    },
-    "orders": {
-        "prompt": "Customer orders",
-        "columns": {
-            "order_id": {"dtype": "integer"},
-            "customer_id": {"dtype": "integer"},
-            "product_name": {"prompt": "product name", "dtype": "string"},
-            "quantity": {"prompt": "quantity ordered", "dtype": "integer"},
-        },
-        "primary_key": "order_id",
-        "foreign_keys": [
-            {
-                "column": "customer_id",
-                "referenced_table": "customers",
-                "prompt": "each customer has between 1 and 3 orders",
-            },
-        ],
-    },
-}
-data = mock.sample(
-    tables=tables,
-    sample_size=3,
-    model="openai/gpt-4o-mini",
-    n_workers=4,
-)
-print(data["customers"])
-#   customer_id             name                     email
-# 0            1        John Smith       john.smith@example.com
-# 1            2      Emily Johnson    emily.johnson@example.com
-# 2            3   Michael Williams michael.williams@example.com
-print(data["orders"])
-#   order_id  customer_id      product_name  quantity
-# 0         1            1  Wireless Headphones         2
-# 1         2            1    Fitness Tracker         1
-# 2         3            2     Phone Charger         3
-# 3         4            2  Wireless Headphones         1
-# 4         5            3    Fitness Tracker         2
-```
-
-6. Create your first self-referencing mock table
+5. Create your first self-referencing mock table with auto-increment integer primary keys
 
 ```python
 from mostlyai import mock
@@ -232,9 +179,9 @@ tables = {
     "employees": {
         "prompt": "Employees of a company",
         "columns": {
-            "employee_id": {"prompt": "the unique id of the employee; sequential", "dtype": "string"},
-            "name": {"prompt": "first name and last name of the president", "dtype": "string"},
-            "boss_id": {"prompt": "the id of the boss of the employee", "dtype": "string"},
+            "employee_id": {"dtype": "integer"},
+            "name": {"prompt": "first name and last name of the employee", "dtype": "string"},
+            "boss_id": {"dtype": "integer"},
             "role": {"prompt": "the role of the employee", "dtype": "string"},
         },
         "primary_key": "employee_id",
@@ -249,20 +196,20 @@ tables = {
 }
 df = mock.sample(tables=tables, sample_size=10, model="openai/gpt-5", n_workers=1)
 print(df)
-#   employee_id              name boss_id                   role
-# 0        B0-1      Patricia Lee    <NA>              President
-# 1        B0-2  Edward Rodriguez    B0-1       VP of Operations
-# 2        B0-3      Maria Cortez    B0-1          VP of Finance
-# 3        B0-4     Thomas Nguyen    B0-1       VP of Technology
-# 4        B0-5        Rachel Kim    B0-2     Operations Manager
-# 5        B0-6     Jeffrey Patel    B0-2      Supply Chain Lead
-# 6        B0-7      Olivia Smith    B0-2  Facilities Supervisor
-# 7        B0-8      Brian Carter    B0-3     Accounting Manager
-# 8        B0-9   Lauren Anderson    B0-3      Financial Analyst
-# 9       B0-10   Santiago Romero    B0-3     Payroll Specialist
+#   employee_id              name  boss_id                   role
+# 0            1      Patricia Lee     <NA>              President
+# 1            2  Edward Rodriguez        1       VP of Operations
+# 2            3      Maria Cortez        1          VP of Finance
+# 3            4     Thomas Nguyen        1       VP of Technology
+# 4            5        Rachel Kim        2     Operations Manager
+# 5            6     Jeffrey Patel        2      Supply Chain Lead
+# 6            7      Olivia Smith        2  Facilities Supervisor
+# 7            8      Brian Carter        3     Accounting Manager
+# 8            9   Lauren Anderson        3      Financial Analyst
+# 9           10   Santiago Romero        3     Payroll Specialist
 ```
 
-7. Enrich existing data with additional columns
+6. Enrich existing data with additional columns
 
 ```python
 from mostlyai import mock

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -1218,7 +1218,9 @@ def _postprocess_table(
 
         # map FK values from strings to integers
         mapping = pk_mappings[fk.referenced_table]
-        df[fk.column] = df[fk.column].astype(str).map(mapping).astype("Int64")
+        df[fk.column] = (
+            df[fk.column].apply(lambda val: mapping.get(str(val)) if pd.notna(val) else None).astype("Int64")
+        )
 
     return df
 

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -1200,10 +1200,8 @@ def _postprocess_table(
         old_values = df[pk_col].tolist()
         new_values = list(range(1, len(df) + 1))
 
-        # build mapping: old string values -> new integers
+        # build mapping: old LLM-generated string values -> new auto-incremented integers
         pk_mappings[table_name] = {str(old): new for old, new in zip(old_values, new_values)}
-        # also map new integer values (for FKs that reference already-processed PKs)
-        pk_mappings[table_name].update({str(new): new for new in new_values})
 
         df[pk_col] = new_values
 

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -1218,9 +1218,7 @@ def _postprocess_table(
 
         # map FK values from strings to integers
         mapping = pk_mappings[fk.referenced_table]
-        df[fk.column] = (
-            df[fk.column].apply(lambda val: mapping.get(str(val)) if pd.notna(val) else None).astype("Int64")
-        )
+        df[fk.column] = df[fk.column].astype(str).map(mapping).astype("Int64")
 
     return df
 

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -249,7 +249,6 @@ class ForeignKeyConfig(BaseModel):
 
 
 def _add_auto_increment_values(df: pd.DataFrame, columns: dict[str, ColumnConfig]) -> pd.DataFrame:
-    """Add auto_increment values to the dataframe."""
     df = df.copy()
     current_id = 1
     
@@ -1027,10 +1026,8 @@ async def _convert_table_rows_generator_to_df(
     # extract rows and convert to DataFrame
     rows = [item["row"] for item in items]
     df = pd.DataFrame(rows)
-    
     # add auto_increment values after all rows are collected
     df = _add_auto_increment_values(df, columns)
-    
     # harmonize dtypes
     df = align_df_dtypes_with_mock_dtypes(df, columns)
     return df

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -124,14 +124,14 @@ class MockConfig(RootModel[dict[str, "TableConfig"]]):
         return self
 
     @model_validator(mode="after")
-    def ensure_primary_key_is_string_dtype(self) -> MockConfig:
+    def ensure_primary_key_is_string_or_integer_dtype(self) -> MockConfig:
         for table_name, table_config in self.root.items():
             if table_config.primary_key:
                 column_config = table_config.columns[table_config.primary_key]
-                if column_config.dtype not in [DType.STRING]:
+                if column_config.dtype not in [DType.STRING, DType.INTEGER]:
                     raise ValueError(
                         f"Primary key column '{table_config.primary_key}' in table '{table_name}' must be one of the following types:"
-                        f" {[DType.STRING.value]}"
+                        f" {[DType.STRING.value, DType.INTEGER.value]}"
                     )
         return self
 
@@ -248,6 +248,7 @@ async def _sample_table(
     non_context_size: int | None,
     n_workers: int,
     llm_config: LLMConfig,
+    config: MockConfig,
     progress_callback: Callable | None = None,
 ) -> pd.DataFrame:
     table_rows_generator = _create_table_rows_generator(
@@ -265,7 +266,13 @@ async def _sample_table(
         progress_callback=progress_callback,
     )
     table_rows_generator = tqdm(table_rows_generator, desc=f"Generating rows for table `{name}`".ljust(45))
-    table_df = await _convert_table_rows_generator_to_df(table_rows_generator=table_rows_generator, columns=columns)
+    table_df = await _convert_table_rows_generator_to_df(
+        table_rows_generator=table_rows_generator,
+        columns=columns,
+        primary_key=primary_keys.get(name),
+        foreign_keys=foreign_keys,
+        config=config,
+    )
     return table_df
 
 
@@ -326,6 +333,15 @@ def _create_table_prompt(
         column_specifications = {
             column: spec for column, spec in column_specifications.items() if column not in existing_data.columns
         }
+    # ensure primary keys stay as string in the prompt, even if dtype is integer
+    if target_primary_key and target_primary_key in column_specifications:
+        if columns[target_primary_key].dtype == DType.INTEGER:
+            column_specifications[target_primary_key]["dtype"] = DType.STRING.value
+    # ensure foreign keys referencing integer primary keys also stay as string in the prompt
+    for fk in foreign_keys:
+        if fk.column in column_specifications:
+            if columns[fk.column].dtype == DType.INTEGER:
+                column_specifications[fk.column]["dtype"] = DType.STRING.value
     prompt += f"{json.dumps(column_specifications, indent=2)}\n\n"
 
     # add previous rows as context to help the LLM generate consistent data
@@ -565,11 +581,17 @@ async def _yield_rows_from_csv_chunks_stream(response: litellm.CustomStreamWrapp
 
 
 def _create_structured_output_schema(
-    columns: dict[str, ColumnConfig], existing_data: pd.DataFrame | None
+    columns: dict[str, ColumnConfig],
+    existing_data: pd.DataFrame | None,
+    primary_key: str | None,
+    foreign_keys: list[ForeignKeyConfig],
 ) -> type[BaseModel]:
-    def create_annotation(column_config: ColumnConfig) -> type:
+    def create_annotation(column_config: ColumnConfig, is_int_pk_or_fk: bool = False) -> type:
         if column_config.values or column_config.dtype is DType.CATEGORY:
             return Literal[tuple(column_config.values)]  # type: ignore
+        # ensure integer primary keys and foreign keys are treated as strings
+        if is_int_pk_or_fk:
+            return str | None
         return {
             DType.INTEGER: int | None,
             DType.FLOAT: float | None,
@@ -585,7 +607,9 @@ def _create_structured_output_schema(
     for column_name, column_config in columns.items():
         if existing_data is not None and column_name in existing_data.columns:
             continue  # skip columns that already exist in existing data
-        annotation = create_annotation(column_config)
+        is_int_pk = primary_key and column_name == primary_key and column_config.dtype == DType.INTEGER
+        is_int_fk = any(fk.column == column_name for fk in foreign_keys) and column_config.dtype == DType.INTEGER
+        annotation = create_annotation(column_config, is_int_pk or is_int_fk)
         fields[column_name] = (annotation, Field(...))
     TableRow = create_model("TableRow", **fields)
     TableRows = create_model("TableRows", rows=(list[TableRow], ...))
@@ -632,8 +656,9 @@ async def _worker(
             # construct schema for Structured Outputs (applies to JSON LLMOutputFormat only)
             structured_output_schema = None
             if llm_output_format == LLMOutputFormat.JSON:
+                pk_col = primary_keys.get(name)
                 structured_output_schema = _create_structured_output_schema(
-                    columns=columns, existing_data=existing_batch
+                    columns=columns, existing_data=existing_batch, primary_key=pk_col, foreign_keys=foreign_keys
                 )
 
             # construct litellm kwargs
@@ -974,14 +999,49 @@ def _align_series_dtypes_with_column_config(series: pd.Series, column_config: Co
     return series
 
 
+def _get_integer_pk_fk_columns(
+    columns: dict[str, ColumnConfig],
+    primary_key: str | None,
+    foreign_keys: list[ForeignKeyConfig],
+    config: MockConfig,
+) -> set[str]:
+    """determine which columns should be kept as strings (integer PKs and FKs that reference integer PKs)"""
+    skip_conversion = set()
+
+    # integer primary keys
+    if primary_key and primary_key in columns and columns[primary_key].dtype == DType.INTEGER:
+        skip_conversion.add(primary_key)
+
+    # foreign keys that reference integer primary keys
+    for fk in foreign_keys:
+        if fk.column in columns and columns[fk.column].dtype == DType.INTEGER:
+            ref_config = config.root.get(fk.referenced_table)
+            if ref_config and ref_config.primary_key:
+                if ref_config.columns[ref_config.primary_key].dtype == DType.INTEGER:
+                    skip_conversion.add(fk.column)
+
+    return skip_conversion
+
+
 async def _convert_table_rows_generator_to_df(
     table_rows_generator: AsyncGenerator[dict],
     columns: dict[str, ColumnConfig],
+    primary_key: str | None = None,
+    foreign_keys: list[ForeignKeyConfig] | None = None,
+    config: MockConfig | None = None,
 ) -> pd.DataFrame:
     def align_df_dtypes_with_mock_dtypes(df: pd.DataFrame, columns: dict[str, ColumnConfig]) -> pd.DataFrame:
         df = df.copy()
+        skip_int_conversion = (
+            _get_integer_pk_fk_columns(columns, primary_key, foreign_keys or [], config) if config else set()
+        )
+
         for column_name, column_config in columns.items():
-            df[column_name] = _align_series_dtypes_with_column_config(df[column_name], column_config)
+            # keep integer PKs and FKs as strings for now (post-processing will convert them)
+            if column_name in skip_int_conversion:
+                df[column_name] = df[column_name].astype("string[pyarrow]")
+            else:
+                df[column_name] = _align_series_dtypes_with_column_config(df[column_name], column_config)
         return df
 
     # consume entire generator
@@ -1024,11 +1084,6 @@ def _harmonize_tables(tables: dict[str, dict], existing_data: dict[str, pd.DataF
             if existing_column not in column_configs
         }
         column_configs = {**existing_column_configs, **column_configs}
-
-        # primary keys are always strings
-        primary_key = table_config.get("primary_key", None)
-        if primary_key is not None:
-            column_configs[primary_key]["dtype"] = DType.STRING
 
         table_config["columns"] = column_configs
     return tables
@@ -1129,6 +1184,49 @@ def _build_execution_plan(config: MockConfig) -> list[str]:
     return execution_plan
 
 
+def _postprocess_table(
+    table_name: str,
+    df: pd.DataFrame,
+    table_config: TableConfig,
+    config: MockConfig,
+    pk_mappings: dict[str, dict[str, int]],
+) -> pd.DataFrame:
+    """convert integer PKs and FKs from strings to auto-incremented integers"""
+    df = df.copy()
+
+    # convert integer primary keys to 1, 2, 3, ... and build mapping
+    pk_col = table_config.primary_key
+    if pk_col and table_config.columns[pk_col].dtype == DType.INTEGER:
+        old_values = df[pk_col].tolist()
+        new_values = list(range(1, len(df) + 1))
+
+        # build mapping: old string values -> new integers
+        pk_mappings[table_name] = {str(old): new for old, new in zip(old_values, new_values)}
+        # also map new integer values (for FKs that reference already-processed PKs)
+        pk_mappings[table_name].update({str(new): new for new in new_values})
+
+        df[pk_col] = new_values
+
+    # convert foreign keys that reference integer primary keys
+    for fk in table_config.foreign_keys:
+        ref_config = config.root[fk.referenced_table]
+        ref_pk_col = ref_config.primary_key
+
+        # skip if not referencing an integer PK
+        if not ref_pk_col or ref_config.columns[ref_pk_col].dtype != DType.INTEGER:
+            continue
+        if fk.referenced_table not in pk_mappings:
+            continue
+
+        # map FK values from strings to integers
+        mapping = pk_mappings[fk.referenced_table]
+        df[fk.column] = (
+            df[fk.column].apply(lambda val: mapping.get(str(val)) if pd.notna(val) else None).astype("Int64")
+        )
+
+    return df
+
+
 async def _sample_common(
     *,
     tables: dict[str, dict],
@@ -1156,6 +1254,9 @@ async def _sample_common(
 
     data: dict[str, pd.DataFrame] = _harmonize_existing_data(existing_data, config) or {}
 
+    # track mappings from old string PK values to new integer PK values
+    pk_mappings: dict[str, dict[str, int]] = {}
+
     for table_name in execution_plan:
         table_config = config.root[table_name]
         df = await _sample_table(
@@ -1170,8 +1271,10 @@ async def _sample_common(
             non_context_size=10,  # pick 10 rows to choose from for each non-context foreign key
             n_workers=n_workers,
             llm_config=llm_config,
+            config=config,
             progress_callback=progress_callback,
         )
+        df = _postprocess_table(table_name, df, table_config, config, pk_mappings)
         data[table_name] = df
 
     return next(iter(data.values())) if len(data) == 1 and return_type == "auto" else data

--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -78,7 +78,7 @@ class MockConfig(RootModel[dict[str, "TableConfig"]]):
 
                 fk_field = table_config.columns[fk.column]
                 pk_field = referenced_config.columns[referenced_config.primary_key]
-                
+
                 # foreign key columns cannot be auto-increment
                 if fk_field.auto_increment:
                     raise ValueError(
@@ -86,7 +86,7 @@ class MockConfig(RootModel[dict[str, "TableConfig"]]):
                         f"Foreign key column '{fk.column}' cannot have auto_increment=True. "
                         f"Foreign keys must reference values from other tables, not generate their own."
                     )
-                
+
                 # foreign key dtype must match primary key dtype
                 if fk_field.dtype != pk_field.dtype:
                     raise ValueError(
@@ -260,12 +260,12 @@ class ForeignKeyConfig(BaseModel):
 
 def _add_auto_increment_values(df: pd.DataFrame, columns: dict[str, ColumnConfig]) -> pd.DataFrame:
     df = df.copy()
-    
+
     for column_name, column_config in columns.items():
         if column_config.auto_increment:
             # each auto-increment column starts at 1 independently
             df[column_name] = list(range(1, 1 + len(df)))
-    
+
     return df
 
 

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -25,8 +25,6 @@ litellm_completion = litellm.completion
 
 def test_single_table():
     def litellm_completion_with_mock_response(*args, **kwargs):
-        # remove unsupported params for mock
-        kwargs.pop("reasoning_effort", None)
         mock_response = '{"rows": [{"guest_id": 1, "nationality": "US", "name": "John Doe", "gender": "male", "age": 25, "date_of_birth": "1990-01-01", "checkin_time": "2025-05-01 10:00:00", "is_vip": true, "price_per_night": 100.0, "room_number": 101}]}'
         return litellm_completion(*args, **kwargs, mock_response=mock_response)
 
@@ -116,8 +114,6 @@ def test_auto_increment_with_foreign_keys():
     def litellm_completion_with_mock_response(*args, **kwargs):
         nonlocal batch
         batch += 1
-        # remove unsupported params for mock
-        kwargs.pop("reasoning_effort", None)
         if batch <= n_workers:
             # mock users: each worker produces 2 rows
             mock_response = f'{{"rows": [{{"id": "B{batch}-1", "name": "Alice", "manager_id": null}}, {{"id": "B{batch}-2", "name": "Bob", "manager_id": "B{batch}-1"}}]}}'

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -109,8 +109,13 @@ def test_auto_increment_with_foreign_keys():
         mock_response = '{"rows": [{"name": "A"}, {"name": "B"}]}'
         return litellm_completion(*args, **kwargs, mock_response=mock_response)
 
-    tables = {"users": {"columns": {"id": {"dtype": "integer", "auto_increment": True}, "name": {"dtype": "string"}}, "primary_key": "id"}}
-    
+    tables = {
+        "users": {
+            "columns": {"id": {"dtype": "integer", "auto_increment": True}, "name": {"dtype": "string"}},
+            "primary_key": "id",
+        }
+    }
+
     with patch("mostlyai.mock.core.litellm.acompletion", side_effect=litellm_completion_with_mock_response):
         df = mock.sample(tables=tables, sample_size=6, n_workers=3)
         assert sorted(df["id"].tolist()) == list(range(1, 7))

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -25,6 +25,8 @@ litellm_completion = litellm.completion
 
 def test_single_table():
     def litellm_completion_with_mock_response(*args, **kwargs):
+        # remove unsupported params for mock
+        kwargs.pop("reasoning_effort", None)
         mock_response = '{"rows": [{"guest_id": 1, "nationality": "US", "name": "John Doe", "gender": "male", "age": 25, "date_of_birth": "1990-01-01", "checkin_time": "2025-05-01 10:00:00", "is_vip": true, "price_per_night": 100.0, "room_number": 101}]}'
         return litellm_completion(*args, **kwargs, mock_response=mock_response)
 
@@ -69,6 +71,8 @@ def test_single_table():
 
 def test_retries():
     def litellm_completion_with_mock_response(*args, **kwargs):
+        # remove unsupported params for mock
+        kwargs.pop("reasoning_effort", None)
         mock_response = '{"rows": [{"name": "John Doe"}]}'
         return litellm_completion(*args, **kwargs, mock_response=mock_response)
 
@@ -104,14 +108,28 @@ def test_existing_data():
 
 
 def test_auto_increment_with_foreign_keys():
-    # test auto-increment integer PKs with self-referencing FK: 3 workers, 6 rows (mocked)
+    # test auto-increment integer PKs with self-referencing FK: 2 workers, 4 user rows, 4 task rows
     # note: LLM generates string PKs which are then remapped to integers in post-processing
     batch = 0
+    n_workers = 2
 
     def litellm_completion_with_mock_response(*args, **kwargs):
         nonlocal batch
         batch += 1
-        mock_response = f'{{"rows": [{{"id": "B{batch}-1", "name": "Alice", "manager_id": null}}, {{"id": "B{batch}-2", "name": "Bob", "manager_id": "B{batch}-1"}}]}}'
+        # remove unsupported params for mock
+        kwargs.pop("reasoning_effort", None)
+        if batch <= n_workers:
+            # mock users: each worker produces 2 rows
+            mock_response = f'{{"rows": [{{"id": "B{batch}-1", "name": "Alice", "manager_id": null}}, {{"id": "B{batch}-2", "name": "Bob", "manager_id": "B{batch}-1"}}]}}'
+        else:
+            # mock tasks: return 1 row per batch, referencing users sequentially
+            row_idx = batch - n_workers  # 1, 2, 3, 4
+            # map row_idx to user string: 1->B1-1, 2->B1-2, 3->B2-1, 4->B2-2
+            batch_num = ((row_idx - 1) // 2) + 1
+            user_num = ((row_idx - 1) % 2) + 1
+            mock_response = (
+                f'{{"rows": [{{"id": "B{row_idx}-1", "name": "Training", "user_id": "B{batch_num}-{user_num}"}}]}}'
+            )
         return litellm_completion(*args, **kwargs, mock_response=mock_response)
 
     tables = {
@@ -123,18 +141,43 @@ def test_auto_increment_with_foreign_keys():
             },
             "primary_key": "id",
             "foreign_keys": [{"column": "manager_id", "referenced_table": "users", "prompt": "manager of the user"}],
-        }
+        },
+        "tasks": {
+            "columns": {
+                "id": {"dtype": "integer"},
+                "name": {"dtype": "string"},
+                "user_id": {"dtype": "integer"},
+            },
+            "primary_key": "id",
+            "foreign_keys": [{"column": "user_id", "referenced_table": "users", "prompt": "user of the task"}],
+        },
     }
 
     with patch("mostlyai.mock.core.litellm.acompletion", side_effect=litellm_completion_with_mock_response):
-        df = mock.sample(tables=tables, sample_size=6, n_workers=3)
-        # check expected structure: auto-increment ids 1-6 (remapped from strings), alternating names
-        # manager_ids should also be remapped (A->1, B->2, etc.)
-        expected = pd.DataFrame(
-            {
-                "id": [1, 2, 3, 4, 5, 6],
-                "name": ["Alice", "Bob", "Alice", "Bob", "Alice", "Bob"],
-                "manager_id": [None, 1, None, 3, None, 5],
-            }
+        result = mock.sample(tables=tables, sample_size=4, n_workers=n_workers)
+        # check expected structure: auto-increment ids 1-4 for users (remapped from strings)
+        # manager_ids should also be remapped (B1-1->1, B2-1->3, etc.)
+        # use pd.testing.assert_frame_equal for better dtype handling
+        pd.testing.assert_frame_equal(
+            result["users"],
+            pd.DataFrame(
+                {
+                    "id": [1, 2, 3, 4],
+                    "name": ["Alice", "Bob", "Alice", "Bob"],
+                    "manager_id": [None, 1.0, None, 3.0],
+                }
+            ),
+            check_dtype=False,
         )
-        pd.testing.assert_frame_equal(df, expected, check_dtype=False)
+        # tasks reference users sequentially: T1->B1-1 (id=1), T2->B1-2 (id=2), T3->B2-1 (id=3), T4->B2-2 (id=4)
+        pd.testing.assert_frame_equal(
+            result["tasks"],
+            pd.DataFrame(
+                {
+                    "id": [1, 2, 3, 4],
+                    "name": ["Training"] * 4,
+                    "user_id": [1, 2, 3, 4],
+                }
+            ),
+            check_dtype=False,
+        )

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -111,7 +111,7 @@ def test_auto_increment_with_foreign_keys():
 
     tables = {
         "users": {
-            "columns": {"id": {"dtype": "integer", "auto_increment": True}, "name": {"dtype": "string"}},
+            "columns": {"id": {"dtype": "integer"}, "name": {"dtype": "string"}},
             "primary_key": "id",
         }
     }


### PR DESCRIPTION
This PR introduces support for integer primary keys with `auto_increment=True`, alongside existing string-based keys.