### PR TITLE
chore: update workflow action references

### DIFF
--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -1,20 +1,20 @@
-name: "pre-commit check"
+name: 'pre-commit check'
 
 on: [workflow_call]
 
 env:
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-  FORCE_COLOR: "1"
+  FORCE_COLOR: '1'
 
 jobs:
   pre-commit-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pre-commit-check.yaml
+++ b/.github/workflows/pre-commit-check.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,10 +1,10 @@
-name: "mostlyai-mock tests"
+name: 'mostlyai-mock tests'
 
 on: [workflow_call]
 
 env:
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-  FORCE_COLOR: "1"
+  FORCE_COLOR: '1'
 
 jobs:
   run-tests:
@@ -14,16 +14,16 @@ jobs:
       packages: write
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
-          submodules: "true"
+          submodules: 'true'
 
       - name: Setup | uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           enable-cache: false
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Setup | Dependencies
         run: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins CI GitHub Actions to specific SHAs and bumps versions for checkout, setup-python, and setup-uv.
> 
> - **CI Workflows** (`.github/workflows/*`):
>   - **pre-commit-check**: Pin `actions/checkout` to commit `8e8c483` (v6.0.1) and `actions/setup-python` to `83679a8` (v6.1.0).
>   - **run-tests**: Pin `actions/checkout` to `8e8c483` (v6.0.1) and `astral-sh/setup-uv` to `ed21f2f` (v7.1.5).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 410366e4dcf4b023e167ce622920a4e1d2aaf558. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->