### PR TITLE
chore: skip use-current-year for LICENSE headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         # - --remove-header
         - --license-filepath
         - LICENSE_HEADER
-        - --use-current-year
+        # - --use-current-year
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts pre-commit license insertion behavior to use a fixed header.
> 
> - In `.pre-commit-config.yaml`, comments out `--use-current-year` for `insert-license`, making headers rely on `LICENSE_HEADER` content rather than updating the year automatically
> - No application code changes; only pre-commit configuration tweak
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b86d1729d0dde7f495a952dc7f1ac04b5de39b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->