### PR TITLE
enhance: make initial batch_size configurable

### DIFF
--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -250,6 +250,7 @@ async def _sample_table(
     llm_config: LLMConfig,
     config: MockConfig,
     progress_callback: Callable[..., Awaitable[None]] | None = None,
+    batch_size = None,
 ) -> pd.DataFrame:
     # provide a default progress callback if none is provided
     if progress_callback is None:
@@ -282,6 +283,7 @@ async def _sample_table(
         n_workers=n_workers,
         llm_config=llm_config,
         progress_callback=progress_callback,
+        batch_size=batch_size,
     )
     table_df = await _convert_table_rows_generator_to_df(
         table_rows_generator=table_rows_generator,
@@ -442,6 +444,7 @@ def _create_table_prompt(
     prompt += f"{verb.capitalize()} data for the Target Table `{name}`.\n\n"
     if n_rows is not None:
         prompt += f"Number of data rows to {verb}: `{n_rows}`.\n\n"
+
 
     if target_primary_key is not None:
         prompt += f"Add prefix to all values of Target Table Primary Key. The prefix is 'B{batch_idx}-'."
@@ -823,8 +826,8 @@ async def _create_table_rows_generator(
     n_workers: int,
     llm_config: LLMConfig,
     progress_callback: Callable[..., Awaitable[None]] | None = None,
+    batch_size: int | None = 20, # generate 20 root table rows at a time
 ) -> AsyncGenerator[dict]:
-    batch_size = 20  # generate 20 root table rows at a time
 
     def supports_structured_outputs(model: str) -> bool:
         model = model.removeprefix("litellm_proxy/")
@@ -1260,6 +1263,7 @@ async def _sample_common(
     n_workers: int = 10,
     return_type: Literal["auto", "dict"] = "auto",
     progress_callback: Callable[..., Awaitable[None]] | None = None,
+    batch_size: int | None = None
 ):
     tables: dict[str, TableConfig] = _harmonize_tables(tables, existing_data)
     config = MockConfig(tables)
@@ -1295,6 +1299,7 @@ async def _sample_common(
             llm_config=llm_config,
             config=config,
             progress_callback=progress_callback,
+            batch_size=batch_size
         )
         data[table_name] = df
 
@@ -1318,6 +1323,7 @@ def sample(
     n_workers: int = 10,
     return_type: Literal["auto", "dict"] = "auto",
     progress_callback: Callable[..., Awaitable[None]] | None = None,
+    batch_size: int | None = None
 ) -> pd.DataFrame | dict[str, pd.DataFrame]:
     """
     Generate synthetic data from scratch or enrich existing data with new columns.
@@ -1605,6 +1611,7 @@ def sample(
             n_workers=n_workers,
             return_type=return_type,
             progress_callback=progress_callback,
+            batch_size=batch_size
         )
         return future.result()
 
@@ -1621,6 +1628,7 @@ async def _asample(
     n_workers: int = 10,
     return_type: Literal["auto", "dict"] = "auto",
     progress_callback: Callable[..., Awaitable[None]] | None = None,
+    batch_size: int | None = None
 ) -> pd.DataFrame | dict[str, pd.DataFrame]:
     return await _sample_common(
         tables=tables,
@@ -1633,6 +1641,7 @@ async def _asample(
         n_workers=n_workers,
         return_type=return_type,
         progress_callback=progress_callback,
+        batch_size=batch_size
     )
 
 


### PR DESCRIPTION

---------

# Pull Request

## Changes

- Make `batch_size` a parameter of `sample()` function.
- Make `batch_size` a parameter of `_sample_table()` function.
- Make `batch_size` a parameter of `_sample_common()` function.
- Make `batch_size` a parameter of `_asample()` function.
- Make `batch_size` a  default parameter of `_create_table_rows_generator`

## Why this change?

The batch size of 20 may not be a good size for larger datasets (~1000 rows) and may encounter rate limiting by some LLM provider

## Testing

- Tested with a test case to assert that the user_prompt contains the configured batch_size 

## Additional Notes

NIL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, parameter-plumbing change that only affects how rows are chunked into LLM calls; default behavior remains the same unless callers pass `batch_size`.
> 
> **Overview**
> Exposes a new optional `batch_size` parameter on `sample()`/`_asample()` and threads it through `_sample_common()` and `_sample_table()` into `_create_table_rows_generator`, replacing the previously hardcoded root-table batch size of 20.
> 
> This allows callers to tune per-request row batching (and thus LLM call sizing/rate-limiting behavior) while keeping existing special-case overrides intact (e.g., linked tables use batch size 1; augmentation uses 10).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2462c1fbe943d491f71653b3e4ee08f3b21149c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->