### PR TITLE
feat: add api_base parameter for OpenAI-compatible endpoints

### DIFF
--- a/mostlyai/mock/core.py
+++ b/mostlyai/mock/core.py
@@ -42,6 +42,7 @@ class LLMOutputFormat(str, Enum):
 class LLMConfig(BaseModel):
     model: str
     api_key: str | None
+    api_base: str | None
     temperature: float
     top_p: float
 
@@ -684,6 +685,7 @@ async def _worker(
                 "top_p": llm_config.top_p,
                 "model": llm_config.model,
                 "api_key": llm_config.api_key,
+                "api_base": llm_config.api_base,
                 "stream": True,
             }
 
@@ -1255,6 +1257,7 @@ async def _sample_common(
     existing_data: dict[str, pd.DataFrame] | None = None,
     model: str = "openai/gpt-5-nano",
     api_key: str | None = None,
+    api_base: str | None = None,
     temperature: float = 1.0,
     top_p: float = 0.95,
     n_workers: int = 10,
@@ -1264,7 +1267,7 @@ async def _sample_common(
     tables: dict[str, TableConfig] = _harmonize_tables(tables, existing_data)
     config = MockConfig(tables)
 
-    llm_config = LLMConfig(model=model, api_key=api_key, temperature=temperature, top_p=top_p)
+    llm_config = LLMConfig(model=model, api_key=api_key, api_base=api_base, temperature=temperature, top_p=top_p)
 
     sample_size: dict[str, int] = _harmonize_sample_size(sample_size, config)
     primary_keys = {table_name: table_config.primary_key for table_name, table_config in config.root.items()}
@@ -1313,6 +1316,7 @@ def sample(
     existing_data: dict[str, pd.DataFrame] | None = None,
     model: str = "openai/gpt-5-nano",
     api_key: str | None = None,
+    api_base: str | None = None,
     temperature: float = 1.0,
     top_p: float = 0.95,
     n_workers: int = 10,
@@ -1354,6 +1358,7 @@ def sample(
             - `anthropic/claude-3-7-sonnet-latest`
             See https://docs.litellm.ai/docs/providers/ for more options.
         api_key (str | None): The API key to use for the LLM. If not provided, LiteLLM will take it from the environment variables.
+        api_base (str | None): Override the API base URL. Useful for OpenAI-compatible self-hosted endpoints. If not provided, LiteLLM uses the default endpoint for the chosen model.
         temperature (float): The temperature to use for the LLM. Default is 1.0.
         top_p (float): The top-p value to use for the LLM. Default is 0.95.
         n_workers (int): The number of concurrent workers making the LLM calls. Default is 10. The value is clamped to the range [1, 10].
@@ -1600,6 +1605,7 @@ def sample(
             existing_data=existing_data,
             model=model,
             api_key=api_key,
+            api_base=api_base,
             temperature=temperature,
             top_p=top_p,
             n_workers=n_workers,
@@ -1616,6 +1622,7 @@ async def _asample(
     existing_data: dict[str, pd.DataFrame] | None = None,
     model: str = "openai/gpt-5-nano",
     api_key: str | None = None,
+    api_base: str | None = None,
     temperature: float = 1.0,
     top_p: float = 0.95,
     n_workers: int = 10,
@@ -1628,6 +1635,7 @@ async def _asample(
         existing_data=existing_data,
         model=model,
         api_key=api_key,
+        api_base=api_base,
         temperature=temperature,
         top_p=top_p,
         n_workers=n_workers,

--- a/mostlyai/mock/mcp_server.py
+++ b/mostlyai/mock/mcp_server.py
@@ -58,6 +58,7 @@ async def mock_data(
     sample_size: int,
     model: str = "openai/gpt-5-nano",
     api_key: str | None = None,
+    api_base: str | None = None,
     temperature: float = 1.0,
     top_p: float = 0.95,
 ) -> dict[str, str]:
@@ -66,6 +67,7 @@ async def mock_data(
         sample_size=sample_size,
         model=model,
         api_key=api_key,
+        api_base=api_base,
         temperature=temperature,
         top_p=top_p,
         return_type="dict",

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -105,6 +105,27 @@ def test_existing_data():
         mock_acompletion.assert_not_called()
 
 
+def test_api_base_forwarded_to_litellm():
+    # api_base flows through to litellm.acompletion
+    captured_kwargs = {}
+
+    def litellm_completion_with_mock_response(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        mock_response = '{"rows": [{"name": "John Doe"}]}'
+        return litellm_completion(*args, **kwargs, mock_response=mock_response)
+
+    tables = {
+        "guests": {
+            "columns": {
+                "name": {"dtype": "string"},
+            },
+        }
+    }
+    with patch("mostlyai.mock.core.litellm.acompletion", side_effect=litellm_completion_with_mock_response):
+        mock.sample(tables=tables, sample_size=1, api_base="https://example.test/v1")
+    assert captured_kwargs.get("api_base") == "https://example.test/v1"
+
+
 def test_auto_increment_with_foreign_keys():
     # test auto-increment integer PKs with self-referencing FK: 2 workers, 4 user rows, 4 task rows
     # note: LLM generates string PKs which are then remapped to integers in post-processing


### PR DESCRIPTION
closes #86

adds an api_base argument that gets forwarded to litellm.acompletion. lets you point at openai-compatible endpoints (self-hosted vllm/ollama/lm studio, internal gateways, litellm proxy) without changing the model string.

\`\`\`python
mock.sample(
    tables=tables,
    sample_size=10,
    model="openai/gpt-4",
    api_base="http://localhost:8000/v1",
)
\`\`\`

mirrors how api_key is wired - new field on LLMConfig, threaded through _sample_common / sample / _asample / mock_data. None means "use litellm default", same semantic as api_key. test captures the kwargs handed to litellm.acompletion and asserts api_base is forwarded.