### PR TITLE
ci: add release bump and PyPI publish workflows (match mostlyai-qa)

### DIFF
--- a/.github/workflows/release-1-bump.yml
+++ b/.github/workflows/release-1-bump.yml
@@ -1,0 +1,60 @@
+name: Release Step 1 - Release on GitHub
+run-name: bump version to ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (e.g. 1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version
+        run: |
+          sed -i -E 's/^version = ".*"/version = "${{ inputs.version }}"/' pyproject.toml
+          sed -i -E 's/^__version__ = ".*"/__version__ = "${{ inputs.version }}"/' mostlyai/mock/__init__.py
+
+      - name: Commit and Push
+        run: |
+          BRANCH_NAME="release-${{ inputs.version }}"
+          git checkout -B $BRANCH_NAME
+          git add pyproject.toml mostlyai/mock/__init__.py
+          git commit -m "build: bump version to ${{ inputs.version }}"
+          git push -f origin $BRANCH_NAME
+
+      - name: Create and Merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_id=$(gh pr list --head release-${{ inputs.version }} --base main --json number --jq '.[0].number')
+          if [ -z "$pr_id" ]; then
+            pr_id=$(gh pr create \
+              --title "build: release ${{ inputs.version }}" \
+              --body "Release version ${{ inputs.version }}." \
+              --base main \
+              --head release-${{ inputs.version }})
+          fi
+          gh pr merge $pr_id --squash
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ inputs.version }} \
+            --title "Release ${{ inputs.version }}" \
+            --generate-notes

--- a/.github/workflows/release-2-publish.yml
+++ b/.github/workflows/release-2-publish.yml
@@ -1,0 +1,50 @@
+name: Release Step 2 - Publish to PyPI
+run-name: publish to pypi
+
+on:
+  workflow_run:
+    workflows: ["Release Step 1 - Release on GitHub"] # Must match name exactly
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to publish'
+        default: 'main'
+        required: false
+
+jobs:
+  pypi-publish:
+    # Only run if Step 1 was successful, or if triggered manually
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    name: Build and publish Python package
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      id-token: write # Required for PyPI Trusted Publishing
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Use branch from trigger, or default to main
+          ref: ${{ github.event.workflow_run.head_branch || inputs.ref || 'main' }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true


### PR DESCRIPTION
Adds GitHub Actions release workflows aligned with mostlyai-qa:

- **Release Step 1:** Manual version bump via workflow_dispatch, PR to main, squash merge, GitHub release with generated notes.
- **Release Step 2:** Publish to PyPI after Step 1 succeeds (or manual dispatch), using uv, OIDC, and `pypa/gh-action-pypi-publish`.

Requires the `release` environment and PyPI trusted publishing to be configured for this repository.

Made with [Cursor](https://cursor.com)