### PR TITLE
Add GitHub Issues URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ mcp-server = "mostlyai.mock.mcp_server:main"
 [project.urls]
 homepage = "https://github.com/mostly-ai/mostlyai-mock"
 repository = "https://github.com/mostly-ai/mostlyai-mock"
+issues = "https://github.com/mostly-ai/mostlyai-mock/issues"
 documentation = "https://mostly-ai.github.io/mostlyai-mock/"
 
 [tool.uv]


### PR DESCRIPTION
## Summary

Add `issues` under `[project.urls]` pointing at `https://github.com/mostly-ai/mostlyai-mock/issues` so packaging metadata exposes the GitHub issue tracker alongside the existing **homepage** and **repository** entries (already `https://github.com/mostly-ai/mostlyai-mock`).

Made with [Cursor](https://cursor.com)